### PR TITLE
Add Info Bar to Title Screen

### DIFF
--- a/src/acaddom.c
+++ b/src/acaddom.c
@@ -22,6 +22,12 @@
 #include "vector.h"
 #include "vbl.h"
 
+#define COPR_INFO                  "(C) 2023 Academia Team"
+#define INFO_BAR_HEIGHT             48
+#define INFO_BAR_ENTRY_HEIGHT       16
+#define LICENSE_INFO               "Licensed under the GPL-2.0-only"
+#define VER_INFO                   "v2023.05.15-NEXT"
+
 #define MIN_NUM_TICKS               14
 #define MIN_NUM_TICKS_IN_SEC         5
 #define MIN_NUM_TICKS_IN_0_8_SEC     4
@@ -177,7 +183,7 @@ int main()
 void displayTitleScreen(UINT32 *screenBuffer, BOOL *exitPgrm, int *numPlayers)
 {
 	const int X_TITLE           =  27;
-	const int Y_TITLE           =  57;
+	const int Y_TITLE           =  77;
 
 	const int X_1P_BUTTON       = 178;
 	const int Y_1P_BUTTON       = 269;
@@ -198,6 +204,21 @@ void displayTitleScreen(UINT32 *screenBuffer, BOOL *exitPgrm, int *numPlayers)
 
 	const int BORDER_HEIGHT      =   3;
 	const int BORDER_WIDTH       =   3;
+	const int Y_INFO_BAR_START   =   BORDER_HEIGHT;
+
+	const int X_COPR             =   0;
+	const int Y_COPR             =   Y_INFO_BAR_START;
+	Label     coprLabel;
+
+	const int X_VER              =   0;
+	const int Y_VER              =   Y_COPR + INFO_BAR_ENTRY_HEIGHT;
+	Label     verLabel;
+
+	const int X_LICENSE          =   0;
+	const int Y_LICENSE          =   Y_VER + INFO_BAR_ENTRY_HEIGHT;
+	Label     licenseLabel;
+	LabelStr  strLicense;
+
 
 	Button       onePlayer;
 	Button       twoPlayer;
@@ -223,9 +244,18 @@ void displayTitleScreen(UINT32 *screenBuffer, BOOL *exitPgrm, int *numPlayers)
 	initButton(&flee, X_FLEE_BUTTON, Y_FLEE_BUTTON,
 			   HEIGHT_FLEE_BUTTON, WIDTH_FLEE_BUTTON, "FLEE");
 
+	initLabel(&coprLabel, X_COPR, Y_COPR, COPR_INFO);
+	initLabel(&verLabel, X_VER, Y_VER, VER_INFO);
+	initLabel(&licenseLabel, X_LICENSE, Y_LICENSE, LICENSE_INFO);
+
 	fill_scrn(screenBuffer);
-	clr_area(screenBuffer, BORDER_WIDTH, SCRN_LEN - (BORDER_WIDTH * 2),
-			 BORDER_HEIGHT, SCRN_HEIGHT - (BORDER_HEIGHT * 2));
+	clr_area(screenBuffer, BORDER_WIDTH, SCRN_LEN - BORDER_WIDTH * 2,
+			 BORDER_HEIGHT + INFO_BAR_HEIGHT,
+			 SCRN_HEIGHT - BORDER_HEIGHT * 2 - INFO_BAR_HEIGHT);
+
+	renderLabel((UINT16 *)screenBuffer, &coprLabel, TRUE);
+	renderLabel((UINT16 *)screenBuffer, &verLabel, TRUE);
+	renderLabel((UINT16 *)screenBuffer, &licenseLabel, TRUE);
 
 	renderTitle(screenBuffer, X_TITLE, Y_TITLE);
 	renderButton(screenBuffer, &onePlayer, FALSE);

--- a/src/acaddom.c
+++ b/src/acaddom.c
@@ -204,21 +204,10 @@ void displayTitleScreen(UINT32 *screenBuffer, BOOL *exitPgrm, int *numPlayers)
 
 	const int BORDER_HEIGHT      =   3;
 	const int BORDER_WIDTH       =   3;
+	const int INFO_BAR_VSPACE    =   0;
+	const int NUM_INFO_BAR_TEXT  =   3;
 	const int Y_INFO_BAR_START   =   BORDER_HEIGHT;
-
-	const int X_COPR             =   0;
-	const int Y_COPR             =   Y_INFO_BAR_START;
-	Label     coprLabel;
-
-	const int X_VER              =   0;
-	const int Y_VER              =   Y_COPR + INFO_BAR_ENTRY_HEIGHT;
-	Label     verLabel;
-
-	const int X_LICENSE          =   0;
-	const int Y_LICENSE          =   Y_VER + INFO_BAR_ENTRY_HEIGHT;
-	Label     licenseLabel;
-	LabelStr  strLicense;
-
+	InfoBar   topInfoBar;
 
 	Button       onePlayer;
 	Button       twoPlayer;
@@ -243,20 +232,15 @@ void displayTitleScreen(UINT32 *screenBuffer, BOOL *exitPgrm, int *numPlayers)
 			   HEIGHT_2P_BUTTON, WIDTH_2P_BUTTON, "2-Player");
 	initButton(&flee, X_FLEE_BUTTON, Y_FLEE_BUTTON,
 			   HEIGHT_FLEE_BUTTON, WIDTH_FLEE_BUTTON, "FLEE");
-
-	initLabel(&coprLabel, X_COPR, Y_COPR, COPR_INFO);
-	initLabel(&verLabel, X_VER, Y_VER, VER_INFO);
-	initLabel(&licenseLabel, X_LICENSE, Y_LICENSE, LICENSE_INFO);
+	initInfoBar(&topInfoBar, Y_INFO_BAR_START, INFO_BAR_VSPACE,
+				NUM_INFO_BAR_TEXT, COPR_INFO, VER_INFO, LICENSE_INFO);
 
 	fill_scrn(screenBuffer);
 	clr_area(screenBuffer, BORDER_WIDTH, SCRN_LEN - BORDER_WIDTH * 2,
 			 BORDER_HEIGHT + INFO_BAR_HEIGHT,
 			 SCRN_HEIGHT - BORDER_HEIGHT * 2 - INFO_BAR_HEIGHT);
 
-	renderLabel((UINT16 *)screenBuffer, &coprLabel, TRUE);
-	renderLabel((UINT16 *)screenBuffer, &verLabel, TRUE);
-	renderLabel((UINT16 *)screenBuffer, &licenseLabel, TRUE);
-
+	renderInfoBar((UINT16 *)screenBuffer, &topInfoBar);
 	renderTitle(screenBuffer, X_TITLE, Y_TITLE);
 	renderButton(screenBuffer, &onePlayer, FALSE);
 	renderButton(screenBuffer, &twoPlayer, FALSE);

--- a/src/model.c
+++ b/src/model.c
@@ -6,6 +6,7 @@
  * @copyright Copyright Academia Team 2023
  */
 
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -41,6 +42,63 @@ int random(int rangeMax)
 	} while (value == 0);
 	
 	return (value % (rangeMax + 1));
+}
+
+void initInfoBar(InfoBar* infoBar, int y, int spacing, int numLabels, ...)
+{
+	const int FINAL_Y = y + (numLabels * (FONT16_HEIGHT + spacing) -
+						spacing - 1);
+
+	va_list argList;
+	int     index;
+
+	infoBar->numLabels = 0;
+	
+	if (numLabels > 0 && numLabels <= MAX_INFO_LABELS &&
+		y >= 0 && y <= SCRN_MAX_Y && FINAL_Y <= SCRN_MAX_Y)
+	{
+		infoBar->y = y;
+		infoBar->spacingBetweenLabels = spacing;
+		va_start(argList, numLabels);
+
+		for (index = 0; index < numLabels; index++)
+		{
+			addInfoText(infoBar, va_arg(argList, char *));
+		}
+	}
+
+	va_end(argList);
+}
+
+void addInfoText(InfoBar* infoBar, char* string)
+{
+	const int NEW_X = SCRN_MID_X - ((strlen(string) * FONT16_WIDTH) >> 1);
+	const int NEW_Y = (infoBar->numLabels == 0 ? infoBar->y :
+					   infoBar->labels[infoBar->numLabels - 1].y +
+					   FONT16_HEIGHT + infoBar->spacingBetweenLabels);
+	const int END_Y = NEW_Y + FONT16_HEIGHT - 1;
+
+	if (infoBar->numLabels < MAX_INFO_LABELS - 1 && END_Y <= SCRN_MAX_Y)
+	{
+		initLabel(&infoBar->labels[infoBar->numLabels++],
+				  (NEW_X < 0 ? 0 : NEW_X), NEW_Y, string);
+	}
+}
+
+void removeInfoText(InfoBar* infoBar, int index)
+{
+	int replaceIndex;
+
+	if (index >= 0 && index < infoBar->numLabels)
+	{
+		for (replaceIndex = index; replaceIndex < infoBar->numLabels - 1;
+			 replaceIndex++)
+		{
+			infoBar->labels[replaceIndex] = infoBar->labels[replaceIndex + 1];
+		}
+
+		infoBar->numLabels--;
+	}
 }
 
 void initWorld (World* world, int numPlayers)

--- a/src/model.h
+++ b/src/model.h
@@ -145,7 +145,7 @@
 /**
  * @brief The maximum number of characters that can be in a label.
  */
-#define MAX_LABEL_LEN 20
+#define MAX_LABEL_LEN 32
 
 
 #define MAX_OBSTACLE_IN_ROW 6

--- a/src/model.h
+++ b/src/model.h
@@ -89,6 +89,7 @@
 #define MAX_HAZARD_IN_ROW 5
 #define MAX_HEDGES 3
 #define MAX_SPIKES 3
+#define MAX_INFO_LABELS 5
 
 #define PLAYER_START_X 304
 #define PLAYER_START_Y 288
@@ -244,6 +245,14 @@ typedef struct
 
 typedef struct
 {
+	int y;
+	int spacingBetweenLabels;
+	int numLabels;
+	Label labels[MAX_INFO_LABELS];
+} InfoBar;
+
+typedef struct
+{
 	int x;
 	HazType hazardType;
 	Orientation orientation;
@@ -384,6 +393,50 @@ typedef struct
  * @return An integral number between 0 and rangeMax, inclusive.
  */
 int random(int rangeMax);
+
+/**
+ * @brief Initializes a InfoBar object.
+ * @details The InfoBar will generate and manage labels corresponding to the
+ * given text. All the labels will be given values such that they will be
+ * horizontally centered on screen. Any invalid values entered will result in
+ * the given object entering an undefined state.
+ * 
+ * @param infoBar A pointer to the InfoBar object to be initialized.
+ * @param y The starting y pixel coordinate for the InfoBar object. Any value
+ * that results in coordinates that are out of bounds is invalid.
+ * @param spacing The amount of vertical space (in pixels) between each label
+ * in the infoBar. Any value that results in coordinates that are out of bounds
+ * in invalid.
+ * @param numLabels The number of labels to place into the object. It must be a
+ * positive number that is less than the currently defined MAX_INFO_LABELS.
+ * @param ... The null-terminated strings that will be stored within the
+ * infoBar. The number of strings must correspond to the value of numLabels.
+ */
+void initInfoBar(InfoBar* infoBar, int y, int spacing, int numLabels, ...);
+
+/**
+ * @brief Adds the given text to the InfoBar object.
+ * @details The text must not cause the InfoBar object to exceed the confines of
+ * the screen. The object will not be modified if there is no more room to add
+ * the text.
+ * 
+ * @param infoBar A pointer to the InfoBar object to be given more text.
+ * @param string The text that should be added to the InfoBar object. Must be
+ * null-terminated.
+ */
+void addInfoText(InfoBar* infoBar, char* string);
+
+/**
+ * @brief Removes the label at the given index from the InfoBar object.
+ * @details The object will not be modified if the index is out of range.
+ * 
+ * @param infoBar A pointer to the InfoBar object that needs to have text
+ * removed.
+ * @param index The zero-indexed value corresponding to text that was previously
+ * added to the object. The largest index always corresponds to the most
+ * recently added text. Any negative index is invalid.
+ */
+void removeInfoText(InfoBar* infoBar, int index);
 
 /**
  * @brief Initializes a CorePlayer object.

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -237,6 +237,16 @@ void renderLabel(UINT16* base, const Label* const label, BOOL blackScreen)
 	}
 }
 
+void renderInfoBar(UINT16* base, const InfoBar* const infoBar)
+{
+	int index;
+
+	for (index = 0; index < infoBar->numLabels; index++)
+	{
+		renderLabel(base, &infoBar->labels[index], TRUE);
+	}
+}
+
 void renderScore(UINT16* base, const Score* const score)
 {
 	const int LABEL_HEIGHT = 16;

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -126,6 +126,17 @@ void renderMainPlayer(UINT32* base, const Player* const player);
 void renderLabel(UINT16* base, const Label* const label, BOOL blackScreen);
 
 /**
+ * @brief Renders a InfoBar to the screen.
+ * @details Every character stored in the infoBar are rendered as 16x16
+ * character sprites. Each string stored within the object is horizontally
+ * centered on the screen at the object's provided y pixel position.
+ * 
+ * @param base The location in memory to plot at.
+ * @param infoBar The infoBar that is to be rendered to the screen.
+ */
+void renderInfoBar(UINT16* base, const InfoBar* const infoBar);
+
+/**
  * @brief Renders a score to the screen.
  * @details Renders the score value (the actual number to be displayed), at the 
  * scores x and y position on screen, top-left corner justified.


### PR DESCRIPTION
It displays copyright, licensing, and version information. The length of a label had to be extended in order to contain all the information. Fixes #9. Also fixes #10.