### PR TITLE
Fix mouseMoved() documentation

### DIFF
--- a/src/in_asm.s
+++ b/src/in_asm.s
@@ -396,7 +396,8 @@ _mouseRclick:			link	a6,#0
 ;
 ; Brief: Checks if the given mouse has moved since last getting the position of
 ; it.
-; Details: The mouse's right click status will be reset after being checked.
+; Details: Once the mouse has been moved, the subroutine will always indicate
+; the mouse has moved until the actual values have been read.
 ;
 ; Param: mouse The mouse to check the movement of.
 ; Return TRUE if the mouse has been moved; FALSE otherwise.

--- a/src/input.h
+++ b/src/input.h
@@ -170,6 +170,8 @@ BOOL mouseRclick(Mouse * const mouse);
 /**
  * @brief Checks if the given mouse has moved since last getting the position of
  * it.
+ * @details Once the mouse has been moved, the subroutine will always indicate
+ * the mouse has moved until the actual values have been read.
  * 
  * @param mouse The mouse to check the movement of.
  * @return TRUE if the mouse has been moved; FALSE otherwise.


### PR DESCRIPTION
The assembly documentation had an invalid description of the subroutine. Also, more details were needed to more accurately reflect what the subroutine does.