### PR TITLE
Move write/read_psg() to assembly

### DIFF
--- a/MAKEFILE
+++ b/MAKEFILE
@@ -1,12 +1,12 @@
-acaddom: src\acaddom.o src\bitmaps.o src\effects.o src\events.o src\font16.o src\input.o src\in_asm.o src\in_vbl.o src\ints_asm.o src\model.o src\move.o src\music.o src\mus_vbl.o src\num_util.o src\psg.o src\raster.o src\rast_asm.o src\renderer.o src\super.o src\su_asm.o src\vbl.o src\vbl_asm.o src\vector.o
-	cc68x -g src\acaddom.o src\bitmaps.o src\effects.o src\events.o src\font16.o src\input.o src\in_asm.o src\in_vbl.o src\ints_asm.o src\model.o src\move.o src\music.o src\mus_vbl.o src\num_util.o src\psg.o src\raster.o src\rast_asm.o src\renderer.o src\super.o src\su_asm.o src\vbl.o src\vbl_asm.o src\vector.o -o bin\acaddom.tos
+acaddom: src\acaddom.o src\bitmaps.o src\effects.o src\events.o src\font16.o src\input.o src\in_asm.o src\in_vbl.o src\ints_asm.o src\model.o src\move.o src\music.o src\mus_vbl.o src\num_util.o src\psg.o src\psg_asm.o src\raster.o src\rast_asm.o src\renderer.o src\super.o src\su_asm.o src\vbl.o src\vbl_asm.o src\vector.o
+	cc68x -g src\acaddom.o src\bitmaps.o src\effects.o src\events.o src\font16.o src\input.o src\in_asm.o src\in_vbl.o src\ints_asm.o src\model.o src\move.o src\music.o src\mus_vbl.o src\num_util.o src\psg.o src\psg_asm.o src\raster.o src\rast_asm.o src\renderer.o src\super.o src\su_asm.o src\vbl.o src\vbl_asm.o src\vector.o -o bin\acaddom.tos
 
 tests: tst_bmp tst_mdl tst_mse tst_mus tst_psg tst_shp tst_sfx
 
 all: acaddom tests
 
-tst_mdl: src\model.o src\arg_list.o src\effects.o src\events.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\psg.o src\rast_asm.o src\super.o src\su_asm.o src\tst_hndl.o src\tst_mdl.o src\move.o src\test.o src\vector.o
-	cc68x -g src\model.o src\arg_list.o src\effects.o src\events.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\psg.o src\rast_asm.o src\super.o src\su_asm.o src\tst_hndl.o src\tst_mdl.o src\test.o src\vector.o -o bin\tst_mdl.tos
+tst_mdl: src\model.o src\arg_list.o src\effects.o src\events.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\psg.o src\psg_asm.o src\rast_asm.o src\super.o src\su_asm.o src\tst_hndl.o src\tst_mdl.o src\move.o src\test.o src\vector.o
+	cc68x -g src\model.o src\arg_list.o src\effects.o src\events.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\psg.o src\psg_asm.o src\rast_asm.o src\super.o src\su_asm.o src\tst_hndl.o src\tst_mdl.o src\test.o src\vector.o -o bin\tst_mdl.tos
 
 src\tst_mdl.o: src\tst_mdl.c src\arg_list.h src\effects.h src\input.h src\model.h src\move.h src\num_util.h src\super.h src\test.h src\tst_hndl.h src\vector.h
 	cc68x -g -c src\tst_mdl.c
@@ -17,14 +17,14 @@ tst_mse: src\tst_mse.o src\arg_list.o src\in_asm.o src\input.o src\ints_asm.o sr
 src\tst_mse.o: src\tst_mse.c src\arg_list.h src\input.h src\test.h src\tst_hndl.h src\types.h src\vector.h
 	cc68x -g -c src\tst_mse.c
 
-tst_mus: src\tst_mus.o src\arg_list.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\music.o src\num_util.o src\psg.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\vector.o src\vbl.o src\vbl_asm.o
-	cc68x -g src\tst_mus.o src\arg_list.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\music.o src\num_util.o src\psg.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\vector.o src\vbl.o src\vbl_asm.o -o bin\tst_mus.tos
+tst_mus: src\tst_mus.o src\arg_list.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\music.o src\num_util.o src\psg.o src\psg_asm.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\vector.o src\vbl.o src\vbl_asm.o
+	cc68x -g src\tst_mus.o src\arg_list.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\music.o src\num_util.o src\psg.o src\psg_asm.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\vector.o src\vbl.o src\vbl_asm.o -o bin\tst_mus.tos
 
 src\tst_mus.o: src\tst_mus.c src\arg_list.h src\input.h src\music.h src\psg.h src\super.h src\test.h src\tst_hndl.h src\types.h src\vbl.h src\vector.h
 	cc68x -g -c src\tst_mus.c
 
-tst_psg: src\psg.o src\arg_list.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\raster.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\tst_psg.o src\vector.o
-	cc68x -g src\psg.o src\arg_list.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\raster.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\tst_psg.o src\vector.o -o bin\tst_psg.tos
+tst_psg: src\psg.o src\psg_asm.o src\arg_list.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\raster.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\tst_psg.o src\vector.o
+	cc68x -g src\psg.o src\psg_asm.o src\arg_list.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\raster.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\tst_psg.o src\vector.o -o bin\tst_psg.tos
 
 src\tst_psg.o: src\tst_psg.c src\psg.h src\arg_list.h src\input.h src\raster.h src\super.h src\test.h src\tst_hndl.h src\types.h src\vector.h
 	cc68x -g -c src\tst_psg.c
@@ -44,8 +44,8 @@ src\tst_shp.o: src\tst_shp.c src\arg_list.h src\bool.h src\raster.h src\scrn.h s
 src\tst_rast.o: src\tst_rast.c src\tst_rast.h src\arg_list.h src\bool.h src\input.h src\raster.h src\scrn.h src\types.h
 	cc68x -g -c src\tst_rast.c
 
-tst_sfx: src\tst_sfx.o src\psg.o src\arg_list.o src\effects.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\vector.o
-	cc68x -g src\tst_sfx.o src\psg.o src\arg_list.o src\effects.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\vector.o -o bin\tst_sfx.tos
+tst_sfx: src\tst_sfx.o src\psg.o src\psg_asm.o src\arg_list.o src\effects.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\vector.o
+	cc68x -g src\tst_sfx.o src\psg.o src\psg_asm.o src\arg_list.o src\effects.o src\input.o src\in_asm.o src\ints_asm.o src\move.o src\num_util.o src\rast_asm.o src\super.o src\su_asm.o src\test.o src\tst_hndl.o src\vector.o -o bin\tst_sfx.tos
 
 src\tst_sfx.o: src\tst_sfx.c src\psg.h src\arg_list.h src\effects.h src\input.h src\test.h src\tst_hndl.h src\vector.h
 	cc68x -g -c src\tst_sfx.c
@@ -79,6 +79,9 @@ src\music.o: src\music.c src\music.h src\ints.h src\psg.h src\super.h src\types.
 
 src\mus_vbl.o: src\mus_vbl.c src\mus_vbl.h src\bool.h src\music.h src\vbl.h
 	cc68x -g -c src\mus_vbl.c
+
+src\psg_asm.o: src\psg_asm.s
+	gen -D -L2 src\psg_asm.s
 
 src\psg.o: src\psg.h src\bool.h src\num_util.h src\super.h src\toggle.h src\types.h
 	cc68x -g -c src\psg.c

--- a/src/psg.c
+++ b/src/psg.c
@@ -13,48 +13,6 @@
 #include "super.h"
 #include "types.h"
 
-void write_psg(PsgReg reg, UINT8 val)
-{
-	const BOOL IS_SUPER = isSu();
-	UINT32 oldSsp;
-
-	volatile UINT8* const REG_SELECT = 0xFFFF8800;
-	volatile UINT8* const WRITE_PSG  = 0xFFFF8802;
-
-	if (reg >= MIN_PSG_REG_NUM && reg <= MAX_PSG_REG_NUM)
-	{
-		if (!IS_SUPER) oldSsp = Su(0);
-
-		*REG_SELECT = reg;
-		*WRITE_PSG  = val;
-
-		if (!IS_SUPER) Su(oldSsp);
-	}
-}
-
-UINT8 read_psg(PsgReg reg)
-{
-	const BOOL IS_SUPER = isSu();
-	UINT32 oldSsp;
-
-	volatile UINT8* const REG_SELECT = 0xFFFF8800;
-	volatile UINT8* const READ_PSG   = 0xFFFF8800;
-
-	UINT8  psgData = 0;
-
-	if (reg >= MIN_PSG_REG_NUM && reg <= MAX_PSG_REG_NUM)
-	{
-		if (!IS_SUPER) oldSsp = Su(0);
-
-		*REG_SELECT = reg;
-		psgData     = *READ_PSG;
-
-		if (!IS_SUPER) Su(oldSsp);
-	}
-
-	return psgData;
-}
-
 
 void set_tone(Channel channel, int tuning)
 {

--- a/src/psg.h
+++ b/src/psg.h
@@ -13,9 +13,6 @@
 #include "toggle.h"
 #include "types.h"
 
-#define MIN_PSG_REG_NUM  0
-#define MAX_PSG_REG_NUM 15
-
 #define MIN_CHANNEL_VAL A_CHANNEL
 #define MAX_CHANNEL_VAL C_CHANNEL
 
@@ -59,14 +56,14 @@ typedef enum
 } PsgReg;
 
 /**
- * @brief Writes the given byte value (0-255) to the given PSG register (0-15)
+ * @brief Writes the given byte value (0-255) to the given PSG register (0-15).
  * @details If any invalid parameter is provided, nothing will be written to a
  * PSG register.
  * 
  * @param reg The register to write to. (0-15)
  * @param val The byte to write to the register (0-255)
  */
-void write_psg(PsgReg reg, UINT8 val);
+void write_psg(PsgReg reg, UINT16 val);
 
 /**
  * @brief Reads the current value stored in the PSG register.

--- a/src/psg.h
+++ b/src/psg.h
@@ -63,7 +63,7 @@ typedef enum
  * @param reg The register to write to. (0-15)
  * @param val The byte to write to the register (0-255)
  */
-void write_psg(PsgReg reg, UINT16 val);
+void write_psg(UINT16 reg, UINT16 val);
 
 /**
  * @brief Reads the current value stored in the PSG register.
@@ -73,7 +73,7 @@ void write_psg(PsgReg reg, UINT16 val);
  * @return The byte value stored in the given register. If the given register is
  * invalid, zero will be returned.
  */
-UINT8 read_psg(PsgReg reg);
+UINT8 read_psg(UINT16 reg);
 
 /**
  * @brief Loads the tone registers (rough and fine) for the given channel

--- a/src/psg_asm.s
+++ b/src/psg_asm.s
@@ -16,7 +16,7 @@ PSG_REG_WRITE:		equ				$FFFF8802
 MAX_PSG_REG_NUM:	equ				15
 MAX_PSG_VAL:		equ				$FF
 
-; void write_psg(PsgReg reg, UINT16 val)
+; void write_psg(UINT16 reg, UINT16 val)
 ;
 ; Brief: Writes the given byte value (0-255) to the given PSG register (0-15).
 ;
@@ -71,7 +71,7 @@ W_PSG_RETURN:		movem.l				(sp)+,d0-d2/d4
 					unlk				a6
 					rts
 
-; UINT8 read_psg(PsgReg reg)
+; UINT8 read_psg(UINT16 reg)
 ;
 ; Brief: Reads a byte value from the given PSG register (0-15).
 ;

--- a/src/psg_asm.s
+++ b/src/psg_asm.s
@@ -1,0 +1,126 @@
+; Includes low-level functions to interact with the Atari ST's Programmable
+; Sound Generator.
+; 
+; Copyright Academia Team 2023
+
+					xdef			_write_psg
+					xdef			_read_psg
+
+					xref			_isSu
+					xref			_Su
+
+PSG_REG_SELECT:		equ				$FFFF8800
+PSG_REG_READ:		equ				$FFFF8800
+PSG_REG_WRITE:		equ				$FFFF8802
+
+MAX_PSG_REG_NUM:	equ				15
+MAX_PSG_VAL:		equ				$FF
+
+; void write_psg(PsgReg reg, UINT16 val)
+;
+; Brief: Writes the given byte value (0-255) to the given PSG register (0-15).
+;
+; Register Table:
+; ---------------
+; d0	-	Holds a value indicating if the subroutine is currently running in
+;			supervisor mode.
+;		-	Holds the old system stack pointer from Su().
+; d1	-	Holds the PSG register to write to.
+; d2	-	Holds the value to write to a PSG register.
+; d4	-	Holds a value indicating if the subroutine has entered supervisor
+;			mode.
+; a6	-	Holds the address of the start of the stack frame.
+
+W_PSG_REG_PARAM:	equ					8
+W_PSG_VAL_PARAM:	equ					10
+
+_write_psg:			link				a6,#0
+					movem.l				d0-d2/d4,-(sp)
+
+					; Enter Supervisor Mode.
+					jsr					_isSu
+					move.b				d0,d4
+					bne					W_PSG_MAIN
+					clr.l				-(sp)
+					jsr					_Su
+					addq.l				#4,sp
+
+					; Confirm that all parameters are in range.
+W_PSG_MAIN:			move.w				W_PSG_REG_PARAM(a6),d1
+					bmi					W_PSG_RETURN
+					cmpi.w				#MAX_PSG_REG_NUM,d1
+					bgt					W_PSG_RETURN
+					move.w				W_PSG_VAL_PARAM(a6),d2
+					cmpi.w				#MAX_PSG_VAL,d2
+					bhi					W_PSG_RETURN
+
+					; Move the register number and the value to write as bytes.
+					; The original parameters were only words for compatibility
+					; with a C compiler.
+					move.b				d1,PSG_REG_SELECT
+					move.b				d2,PSG_REG_WRITE
+
+					; Leave Supervisor Mode.
+					tst.b				d4
+					bne					W_PSG_RETURN
+					move.l				d0,-(sp)
+					jsr					_Su
+					addq.l				#4,sp
+
+W_PSG_RETURN:		movem.l				(sp)+,d0-d2/d4
+					unlk				a6
+					rts
+
+; UINT8 read_psg(PsgReg reg)
+;
+; Brief: Reads a byte value from the given PSG register (0-15).
+;
+; Details: If any invalid parameter is provided, nothing will be written to a
+;		   PSG register.
+;
+; Register Table:
+; ---------------
+; d0	-	Holds a value indicating if the subroutine is currently running in
+;			supervisor mode.
+;		-	Holds the old system stack pointer from Su().
+;		-	Holds the PSG register value to be returned.
+; d1	-	Holds the PSG register to write to.
+; d4	-	Holds a value indicating if the subroutine has entered supervisor
+;			mode.
+; d5	-	Temporarily holds the value to return.
+; a6	-	Holds the address of the start of the stack frame.
+
+R_PSG_REG_PARAM:	equ					8
+
+_read_psg:			link				a6,#0
+					movem.l				d1/d4-d5,-(sp)
+
+					; Enter Supervisor Mode.
+					jsr					_isSu
+					move.b				d0,d4
+					bne					R_PSG_MAIN
+					clr.l				-(sp)
+					jsr					_Su
+					addq.l				#4,sp
+
+					; Confirm that the parameter is in range.
+R_PSG_MAIN:			clr.l				d5
+					move.w				R_PSG_REG_PARAM(a6),d1
+					bmi					R_PSG_RETURN
+					cmpi.w				#MAX_PSG_REG_NUM,d1
+					bgt					R_PSG_RETURN
+
+					move.b				d1,PSG_REG_SELECT
+					move.b				PSG_REG_READ,d5
+
+					; Leave Supervisor Mode.
+					tst.b				d4
+					bne					R_PSG_RETURN
+					move.l				d0,-(sp)
+					jsr					_Su
+					addq.l				#4,sp
+
+R_PSG_RETURN:		move.b				d5,d0
+					movem.l				(sp)+,d1/d4-d5
+					unlk				a6
+					rts


### PR DESCRIPTION
Setting a pointing to a custom address is not supported in ANSI C. Fixes warning 113 from VBCC.