### PR TITLE
Remove unused variables from setPlayerDir()

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -365,10 +365,6 @@ void setPlayerDir(Player* player, Direction dir)
 
 	MoveFrame futureMovement;
 
-	BOOL dirValid = TRUE;
-	int  desiredX = player->x;
-	int  desiredY = player->y;
-
 	UINT32 oldSsp;
 	int    oldIpl;
 


### PR DESCRIPTION
Fixes warning 65 from VBCC for that function.